### PR TITLE
Prefill

### DIFF
--- a/alephant-logger-cloudwatch.gemspec
+++ b/alephant-logger-cloudwatch.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3"
-  spec.add_development_dependency "aws-sdk"
+  spec.add_development_dependency "aws-sdk", "~> 1"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake-rspec"
   spec.add_development_dependency "rspec-nc"

--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -4,7 +4,7 @@ module Alephant
   module Logger
     class CloudWatch
       def initialize(opts)
-        @opts = opts
+        @defaults   = opts
         @cloudwatch = AWS::CloudWatch.new
       end
 
@@ -14,7 +14,7 @@ module Alephant
 
       private
 
-      attr_reader :cloudwatch
+      attr_reader :cloudwatch, :defaults
 
       def parse(dimensions)
         dimensions.map do |name, value|
@@ -28,12 +28,12 @@ module Alephant
       def send_metric(name, value, unit, dimensions)
         Thread.new do
           cloudwatch.put_metric_data(
-            :namespace   => @opts[:namespace],
+            :namespace   => defaults[:namespace],
             :metric_data => [{
               :metric_name => name,
-              :value       => value || @opts[:value],
-              :unit        => unit || @opts[:unit] || "None",
-              :dimensions  => parse(dimensions || @opts[:dimensions] || {})
+              :value       => value || defaults[:value],
+              :unit        => unit || defaults[:unit] || "None",
+              :dimensions  => parse(dimensions || defaults[:dimensions] || {})
             }]
           )
         end

--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -4,8 +4,12 @@ module Alephant
   module Logger
     class CloudWatch
       def initialize(opts)
-        @defaults   = opts
         @cloudwatch = AWS::CloudWatch.new
+
+        preset_defaults = { :unit => "Count", :value => 1, :dimensions => {} }
+        preset_defaults.each do |key, value|
+          @defaults[key] = opts.fetch(key) { value }
+        end
       end
 
       def metric(opts)
@@ -32,8 +36,8 @@ module Alephant
             :metric_data => [{
               :metric_name => name,
               :value       => value || defaults[:value],
-              :unit        => unit || defaults[:unit] || "None",
-              :dimensions  => parse(dimensions || defaults[:dimensions] || {})
+              :unit        => unit || defaults[:unit],
+              :dimensions  => parse(dimensions || defaults[:dimensions])
             }]
           )
         end

--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -3,11 +3,8 @@ require "aws-sdk"
 module Alephant
   module Logger
     class CloudWatch
-      def initialize(namespace, unit = "Count", value = 1, dimensions = {})
-        @namespace  = namespace
-        @unit       = unit
-        @value      = value
-        @dimensions = dimensions
+      def initialize(opts)
+        @opts = opts
         @cloudwatch = AWS::CloudWatch.new
       end
 
@@ -17,7 +14,7 @@ module Alephant
 
       private
 
-      attr_reader :cloudwatch, :namespace
+      attr_reader :cloudwatch
 
       def parse(dimensions)
         dimensions.map do |name, value|
@@ -31,12 +28,12 @@ module Alephant
       def send_metric(name, value, unit, dimensions)
         Thread.new do
           cloudwatch.put_metric_data(
-            :namespace   => namespace,
+            :namespace   => @opts[:namespace],
             :metric_data => [{
               :metric_name => name,
-              :value       => value || @value,
-              :unit        => unit || @unit || "None",
-              :dimensions  => parse(dimensions || @dimensions || {})
+              :value       => value || @opts[:value],
+              :unit        => unit || @opts[:unit] || "None",
+              :dimensions  => parse(dimensions || @opts[:dimensions] || {})
             }]
           )
         end

--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -3,8 +3,11 @@ require "aws-sdk"
 module Alephant
   module Logger
     class CloudWatch
-      def initialize(namespace)
-        @namespace = namespace
+      def initialize(namespace, unit = "Count", value = 1, dimensions = {})
+        @namespace  = namespace
+        @unit       = unit
+        @value      = value
+        @dimensions = dimensions
         @cloudwatch = AWS::CloudWatch.new
       end
 
@@ -31,9 +34,9 @@ module Alephant
             :namespace   => namespace,
             :metric_data => [{
               :metric_name => name,
-              :value       => value,
-              :unit        => unit || "None",
-              :dimensions  => parse(dimensions || {})
+              :value       => value || @value,
+              :unit        => unit || @unit || "None",
+              :dimensions  => parse(dimensions || @dimensions || {})
             }]
           )
         end

--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -5,11 +5,9 @@ module Alephant
     class CloudWatch
       def initialize(opts)
         @cloudwatch = AWS::CloudWatch.new
-
-        preset_defaults = { :unit => "Count", :value => 1, :dimensions => {} }
-        preset_defaults.each do |key, value|
-          @defaults[key] = opts.fetch(key) { value }
-        end
+        @defaults = preset_defaults.reduce({}) do |acc, (key, value)|
+          acc.tap { |h| h[key] = opts.fetch(key, value) }
+        end.tap { |h| h[:namespace] = opts.fetch(:namespace) }
       end
 
       def metric(opts)
@@ -19,6 +17,10 @@ module Alephant
       private
 
       attr_reader :cloudwatch, :defaults
+
+      def preset_defaults
+        { :unit => "Count", :value => 1, :dimensions => {} }
+      end
 
       def parse(dimensions)
         dimensions.map do |name, value|

--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -7,7 +7,7 @@ module Alephant
         @cloudwatch = AWS::CloudWatch.new
         @defaults = preset_defaults.reduce({}) do |acc, (key, value)|
           acc.tap { |h| h[key] = opts.fetch(key, value) }
-        end.tap { |h| h[:namespace] = opts.fetch(:namespace) }
+        end.merge :namespace => opts.fetch(:namespace)
       end
 
       def metric(opts)

--- a/spec/cloudwatch_spec.rb
+++ b/spec/cloudwatch_spec.rb
@@ -1,7 +1,7 @@
 require "alephant/logger/cloudwatch"
 
 describe Alephant::Logger::CloudWatch do
-  subject { described_class.new("namespace") }
+  subject { described_class.new(:namespace => "namespace") }
 
   let(:namespace) { "namespace" }
 


### PR DESCRIPTION
![getinsertpic.com](http://media1.giphy.com/media/goBtJPCmBskVO/200.gif)
## Problem

In some situations we may want to prefill in the unit, value and dimensions properties for an AWS metric. The name property will always be unique though.
## Solution

This PR allows us to prefill in the values but still allow overriding them when calling the `metric` method
