### PR TITLE
Change metric signature so it'll be unified (soon, not yet) with statsd logger

### DIFF
--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -8,13 +8,14 @@ module Alephant
         @defaults   = process_defaults opts
       end
 
-      def metric(opts)
-        send_metric(*opts.values_at(:name, :value, :unit, :dimensions))
+      def metric(name, opts)
+        signature = [name] + opts.values_at(:value, :unit, :dimensions)
+        send_metric(*signature)
       end
 
       private
 
-      attr_reader :cloudwatch, :defaults
+      attr_reader :cloudwatch, :namespace, :defaults
 
       def process_defaults(opts)
         preset_defaults.reduce({}) do |acc, (key, value)|
@@ -38,7 +39,7 @@ module Alephant
       def send_metric(name, value, unit, dimensions)
         Thread.new do
           cloudwatch.put_metric_data(
-            :namespace   => defaults[:namespace],
+            :namespace   => namespace,
             :metric_data => [{
               :metric_name => name,
               :value       => value || defaults[:value],

--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -39,7 +39,7 @@ module Alephant
       def send_metric(name, value, unit, dimensions)
         Thread.new do
           cloudwatch.put_metric_data(
-            :namespace   => namespace,
+            :namespace   => defaults[:namespace],
             :metric_data => [{
               :metric_name => name,
               :value       => value || defaults[:value],

--- a/spec/cloudwatch_spec.rb
+++ b/spec/cloudwatch_spec.rb
@@ -3,12 +3,12 @@ require "alephant/logger/cloudwatch"
 describe Alephant::Logger::CloudWatch do
   subject { described_class.new(:namespace => "namespace") }
 
+  let(:name) { "a" }
   let(:namespace) { "namespace" }
 
   describe "#metric" do
     let(:opts) do
       {
-        :name       => "a",
         :value      => "b",
         :unit       => "c",
         :dimensions => {
@@ -39,7 +39,7 @@ describe Alephant::Logger::CloudWatch do
           :metric_data => [metric_data]
         )
 
-      subject.metric(opts).join
+      subject.metric(name, opts).join
     end
   end
 end


### PR DESCRIPTION
## Problem

We're adding metrics across newsbeat and elections. We ideally want the `metrics` call to be a unified interface across this gem and the `alephant-logger-statsd` otherwise we'll have to go back and change them all if we decide to switch from CloudWatch to StatsD
## Solution

This PR makes the `metric` signature look like: `.metric("foo", { :unit => "Count", :value => 1 })`

> Note: we typically use camel case values (e.g. "FooBarBaz") but we can't ensure camel casing the name passed in (e.g. "foobarbaz" as `capitalize` will only cap the first letter + regex word boundaries can't pick apart that example string) 

This unified `metric` call means the statsd logger can be updated to use `.metric("foo.bar")` and the second argument can be quietly ignored.
## Release Process

How does merging this affect existing repos/gems? I think some repos may need to be set to `0.0.2` version of alephant-logger-cloudwatch before this is merged (although the current `1.0.0` release will cause existing repos to break already if they get built so the change probably should happen ASAP)
