### PR TITLE
Coerce dimension names & keys to strings

### DIFF
--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -30,8 +30,8 @@ module Alephant
       def parse(dimensions)
         dimensions.map do |name, value|
           {
-            :name  => name,
-            :value => value
+            "name"  => name.to_s,
+            "value" => value
           }
         end
       end


### PR DESCRIPTION
![gif](http://3.bp.blogspot.com/-TO7SUJryswY/T2YXlJ5RhHI/AAAAAAAAAPI/aDwsGdcRfd8/s1600/Two_sources_interference.gif)
## Problem

Some consuming applications have mistakenly passed keys/values in the dimension hash as symbols instead of strings.  The AWS SDK expects strings and subsequently raises `AWS::Core::OptionGrammar::FormatError`.  This led to silent failures as the exceptions were being raised in threads separate to the main application (spawned by `alephant-logger`) when firing off metrics.
## Solution

`to_s` dimension names and keys so that the AWS SDK correctly receives strings instead of symbols.
