### PR TITLE
Provide default argument value

### DIFF
--- a/lib/alephant/logger/cloudwatch.rb
+++ b/lib/alephant/logger/cloudwatch.rb
@@ -8,7 +8,7 @@ module Alephant
         @defaults   = process_defaults opts
       end
 
-      def metric(name, opts)
+      def metric(name, opts={})
         signature = [name] + opts.values_at(:value, :unit, :dimensions)
         send_metric(*signature)
       end


### PR DESCRIPTION
## Problem

Can't just provide a metric name to the `metric` call
## Solution

Fixes https://github.com/BBC-News/alephant-logger-cloudwatch/issues/4
